### PR TITLE
Add default timezone to get-defaults action

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ Test the module using the `test-module.sh` script:
 
 The tests are made using [Robot Framework](https://robotframework.org/)
 
+## get-defaults Action
+
+The `get-defaults` action retrieves the default configuration values for NethVoice. It includes the following fields:
+
+- `accepted_timezone_list`: List of accepted timezones.
+- `default_timezone`: Current timezone of the node.
+
+Example output schema:
+```json
+{
+  "accepted_timezone_list": [
+    "Europe/Amsterdam",
+    "Europe/Berlin",
+    "Europe/Brussels",
+    "Europe/London"
+  ],
+  "default_timezone": "Europe/Rome"
+}
+```
 
 ## Music
 

--- a/imageroot/actions/get-defaults/10defaults
+++ b/imageroot/actions/get-defaults/10defaults
@@ -14,8 +14,13 @@ command = "find *  -type f -or -type l"
 # Get the list of timezones
 accepted_timezone_list = subprocess.check_output(command, cwd=timezones_directory, text=True, shell=True).splitlines()
 
+# Retrieve the current timezone of the node
+current_timezone_command = "timedatectl show -p Timezone --value"
+default_timezone = subprocess.check_output(current_timezone_command, text=True, shell=True).strip()
+
 config={
         "accepted_timezone_list": accepted_timezone_list,
+        "default_timezone": default_timezone,
         }
 
 json.dump(config, fp=sys.stdout)

--- a/imageroot/actions/get-defaults/validate-output.json
+++ b/imageroot/actions/get-defaults/validate-output.json
@@ -10,12 +10,13 @@
         "Europe/Berlin",
         "Europe/Brussels",
         "Europe/London"
-      ]
+      ],
+      "default_timezone": "Europe/Rome"
     }
   ],
   "type": "object",
   "additionalProperties": false,
-  "required": ["accepted_timezone_list"],
+  "required": ["accepted_timezone_list", "default_timezone"],
   "properties": {
     "accepted_timezone_list": {
       "description": "List of accepted timezones",
@@ -23,6 +24,10 @@
       "items": {
         "type": "string"
       }
+    },
+    "default_timezone": {
+      "description": "Current timezone of the node",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
Add documentation for the `default_timezone` field in the `get-defaults` action.

* Create a new section for the `get-defaults` action in the README.md file.
* Include details about the `accepted_timezone_list` and `default_timezone` fields.
* Provide an example output schema for the `get-defaults` action.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Amygos/ns8-nethvoice?shareId=9692f207-ecb7-4170-9eb6-0d7b802476d5).