### PR TITLE
action: release module on PR merge to main

### DIFF
--- a/.github/workflows/create-testing-release.yml
+++ b/.github/workflows/create-testing-release.yml
@@ -1,0 +1,23 @@
+name: NS8 Release on PR Merge to Main
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  REPO: ${{ github.repository }}
+
+jobs:
+  release-module:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      !contains(github.event.pull_request.labels.*.name, 'translation')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install NS8 Release Module Extension
+        run: gh extension install NethServer/gh-ns8-release-module
+
+      - name: Create Testing Release
+        run: gh ns8-release-module create --repo ${{ github.repository }} --testing


### PR DESCRIPTION
This GitHub Action triggers a testing release when a PR is merged into the `main` branch, excluding PRs with the `translation` label. It installs the `gh-ns8-release-module` extension and runs the create testing release command.