### PR TITLE
action: release module on PR merge to main

### DIFF
--- a/.github/workflows/create-testing-release.yml
+++ b/.github/workflows/create-testing-release.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 
 env:
-  REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   release-module:


### PR DESCRIPTION
This GitHub Action triggers a testing release when a PR is merged into the `main` branch, excluding PRs with the `translation` label. It installs the `gh-ns8-release-module` extension and runs the create testing release command.